### PR TITLE
BC-818: Stackoverflow error fix when more than 70k results are used

### DIFF
--- a/forgetsy.gemspec
+++ b/forgetsy.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'redis', '> 2.0'
   gem.add_runtime_dependency 'redis-namespace', '>= 1.1.0'
   gem.add_runtime_dependency 'activesupport', '>= 3.2.0'
-  gem.add_development_dependency 'rspec', '~> 2.13.0'
+  gem.add_development_dependency 'rspec', '~> 2.14.0'
   gem.add_development_dependency 'rake', '~> 0.9'
 end

--- a/lib/forgetsy.rb
+++ b/lib/forgetsy.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext'
 
 require 'forgetsy/set'

--- a/lib/forgetsy/delta.rb
+++ b/lib/forgetsy/delta.rb
@@ -69,13 +69,12 @@ module Forgetsy
 
       # do not delegate the limit to sets
       # as we want to apply the limit after norm.
-      limit = opts[:n]
-      opts.delete(:n)
-      bin = opts.key?(:bin) ? opts[:bin] : nil
+      limit = opts.delete(:n)
+      bin   = opts.key?(:bin) ? opts[:bin] : nil
 
       if bin.nil?
         counts = primary_set.fetch(opts)
-        norm = secondary_set.fetch(opts)
+        norm   = secondary_set.fetch(opts)
         result = counts.map do |k, v|
           norm_v = norm.fetch(k, nil)
           v = norm_v.nil? ? 0 : v / Float(norm_v)
@@ -84,18 +83,18 @@ module Forgetsy
       else
         # fetch a single bin.
         counts = primary_set.fetch(opts)
-        norm = secondary_set.fetch(opts)
+        norm   = secondary_set.fetch(opts)
 
         if norm[bin].nil?
-          result = [bin, nil]
+          result = [[bin, nil]]
         else
           norm_v = counts[bin] / Float(norm[bin])
-          result = [bin, norm_v]
+          result = [[bin, norm_v]]
         end
       end
 
       result = result[0..limit - 1] unless limit.nil?
-      Hash[*result.flatten]
+      Hash[result.map { |r| [r[0], r[1]] } ]
     end
 
     # Increment a bin. Additionally supply a date option

--- a/lib/forgetsy/set.rb
+++ b/lib/forgetsy/set.rb
@@ -58,12 +58,12 @@ module Forgetsy
       scrub if opts.fetch(:scrub, true)
 
       if opts.key?(:bin)
-        result = [opts[:bin], @conn.zscore(@name, opts[:bin])]
+        result = [[opts[:bin], @conn.zscore(@name, opts[:bin])]]
       else
         result = fetch_raw(limit: limit)
       end
 
-      Hash[*result.flatten]
+      Hash[result.map { |r| [r[0], r[1]] } ]
     end
 
     # Apply exponential time decay and


### PR DESCRIPTION
### Summary
- [BC-818](https://lessonplanet.atlassian.net/browse/BC-818)
- `Hash[*result.flatten]` crashes with stack level too deep if we have more than 70k results in redis
